### PR TITLE
limit whitelisted auth routes to specific methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "structure-auth",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Authentication & authorization, cause no one likes to share yet everyone wants to be in charge",
   "main": "dist/index.js",
   "dependencies": {

--- a/src/middleware/auth-token.js
+++ b/src/middleware/auth-token.js
@@ -7,19 +7,25 @@ const errorComposer = new StructureComposeError(errorCodes)
 
 const apiRoot = `/api/${process.env.API_VERSION}`
 const whitelistedRoutes = [
-  `${apiRoot}$`,
-  `${apiRoot}/sync`,
-  `${apiRoot}/auth/login$`,
-  `${apiRoot}/auth/users/.*/password/reset`
+  ['GET', `${apiRoot}$`],
+  ['POST', `${apiRoot}/sync`],
+  ['POST', `${apiRoot}/auth/login$`],
+  ['POST', `${apiRoot}/auth/users/.*/password/reset`],
+  ['GET', `${apiRoot}/users/existence/.*$`],
+  ['POST', `${apiRoot}/users$`]
 ]
 
-function isWhiteListedUrl(url) {
+function isWhiteListedUrl(req) {
 
   for (const route of whitelistedRoutes) {
 
-    const re = new RegExp(route)
+    if (route[0] !== req.method) {
+      continue
+    }
 
-    if (re.test(url)) {
+    const re = new RegExp(route[1])
+
+    if (re.test(req.originalUrl)) {
       return true
     }
 
@@ -73,7 +79,7 @@ export default async function authenticateAuthToken(req, res, next) {
 
     try {
 
-      if (isWhiteListedUrl(req.originalUrl)) {
+      if (isWhiteListedUrl(req)) {
         return next()
       }
 

--- a/test/integration/middleware/auth-token.js
+++ b/test/integration/middleware/auth-token.js
@@ -71,6 +71,7 @@ describe('Auth Token Middleware', function() {
 
     const req = {
       headers: {},
+      method: 'GET',
       originalUrl: '/api/0.1'
     }
 
@@ -85,6 +86,7 @@ describe('Auth Token Middleware', function() {
 
     const req = {
       headers: {},
+      method: 'POST',
       originalUrl: '/api/0.1/sync'
     }
 
@@ -99,7 +101,38 @@ describe('Auth Token Middleware', function() {
 
     const req = {
       headers: {},
+      method: 'POST',
       originalUrl: '/api/0.1/auth/login'
+    }
+
+    authenticateAuthToken(req, {}, function(error) {
+      expect(error).to.equal(undefined)
+      done()
+    })
+
+  })
+
+  it('shouldnt need auth for /users/existence/username/tom GET', async function(done) {
+
+    const req = {
+      headers: {},
+      method: 'GET',
+      originalUrl: '/api/0.1/users/existence/username/tom'
+    }
+
+    authenticateAuthToken(req, {}, function(error) {
+      expect(error).to.equal(undefined)
+      done()
+    })
+
+  })
+
+  it('shouldnt need auth for /users POST', async function(done) {
+
+    const req = {
+      headers: {},
+      method: 'POST',
+      originalUrl: '/api/0.1/users'
     }
 
     authenticateAuthToken(req, {}, function(error) {
@@ -113,6 +146,7 @@ describe('Auth Token Middleware', function() {
 
     const req = {
       headers: {},
+      method: 'POST',
       originalUrl: '/api/0.1/auth/users/fake@example.com/password/reset'
     }
 
@@ -127,6 +161,7 @@ describe('Auth Token Middleware', function() {
 
     const req = {
       headers: {},
+      method: 'POST',
       originalUrl: '/api/0.1/auth/users/fake@example.com/password/reset/confirm'
     }
 


### PR DESCRIPTION
also whitelist GET `/users/existence/*` and POST `/users` for signup page